### PR TITLE
PETSc 3.9 fixes for pySIT

### DIFF
--- a/pysit/solvers/constant_density_acoustic/frequency/constant_density_acoustic_frequency_scalar_base.py
+++ b/pysit/solvers/constant_density_acoustic/frequency/constant_density_acoustic_frequency_scalar_base.py
@@ -123,8 +123,11 @@ class ConstantDensityAcousticFrequencyScalarBase(ConstantDensityAcousticFrequenc
         try:
             linear_solver = wrapper.factorize(H, petsc, PETSc.COMM_WORLD)
             Uhat = linear_solver(B.getDenseArray())
-        except:
-            raise SyntaxError('petsc = '+str(petsc)+' is not a correct solver you can only use \'superlu_dist\', \'mumps\' or \'mkl_pardiso\' ')               
+        except Exception as e:
+            if "Could not locate solver package" in str(e):
+                raise SyntaxError('petsc = '+str(petsc)+' is not a correct solver you can only use \'superlu_dist\', \'mumps\' or \'mkl_pardiso\' ')
+            else:
+                raise e
         
         Uhat = Uhat[xrange(usize),:]
 

--- a/pysit/util/wrappers/petsc.py
+++ b/pysit/util/wrappers/petsc.py
@@ -57,7 +57,11 @@ class PetscWrapper():
         pc = ksp.getPC()
         pc.setType('lu') # setting the preconditioner to use an LU factorization
 
-        pc.setFactorSolverPackage(self.solverType) # using mumps as a sparse algorithm
+        petsc_version = petsc4py.__version__.split('.')
+        if int(petsc_version[0]) > 3 or (int(petsc_version[0]) = 3 and int(petsc_version[1]) >= 9):
+            pc.setFactorSolverType(self.solverType) # using mumps as a sparse algorithm
+        else:
+            pc.setFactorSolverPackage(self.solverType) # using mumps as a sparse algorithm
 
         # setting the solvers from the options
         pc.setFromOptions()


### PR DESCRIPTION
A fix for pySIT that makes it compatible with PETSc 3.9
and a patch that avoids a misleading error message.